### PR TITLE
Fix PLY IO logic

### DIFF
--- a/menpo3d/io/output/extensions.py
+++ b/menpo3d/io/output/extensions.py
@@ -6,7 +6,14 @@ landmark_types = {
     '.ljson': ljson_exporter
 }
 
-mesh_types = {
-    '.obj': obj_exporter,
+mesh_types_buffer_support = {
+    '.obj': obj_exporter
+}
+
+mesh_types_paths_only = {
     '.ply': ply_exporter
 }
+
+mesh_types = {}
+mesh_types.update(mesh_types_buffer_support)
+mesh_types.update(mesh_types_paths_only)

--- a/menpo3d/io/output/mesh.py
+++ b/menpo3d/io/output/mesh.py
@@ -1,5 +1,8 @@
-from menpo.shape.mesh import TexturedTriMesh
 import numpy as np
+
+from menpo.io.output.base import _enforce_only_paths_supported
+from menpo.shape.mesh import TexturedTriMesh
+
 
 def obj_exporter(mesh, file_handle, **kwargs):
     r"""
@@ -34,52 +37,55 @@ def obj_exporter(mesh, file_handle, **kwargs):
         for t in (mesh.trilist + 1):
             file_handle.write('f {} {} {}\n'.format(*t).encode('utf-8'))
 
-def ply_exporter(mesh, file_handle, binary = False, **kwargs):
+
+def ply_exporter(mesh, file_path, binary=False, **kwargs):
     r"""
-    Given a file handle to write in to (which should act like a Python `file`
-    object), write out the mesh data. No value is returned.
+    Given a file path to write in to write out the mesh data.
+    No value is returned. Only file paths are supported and if a file handle
+    is passed it will be ignored and a warning will be raised.
 
     Note that this does not save out textures of textured images, and so should
     not be used in isolation.
 
     Parameters
     ----------
-    file_handle : `str`
+    file_path : `str`
         The full path where the obj will be saved out.
     mesh : :map:`TriMesh`
         Any subclass of :map:`TriMesh`. If :map:`TexturedTriMesh` texture
         coordinates will be saved out. Note that :map:`ColouredTriMesh`
-        will only have shape data saved out, as .OBJ doesn't robustly support
+        will only have shape data saved out, as .PLY doesn't robustly support
         per-vertex colour information.
     binary: `bool`, optional
         Specify whether to format output in binary or ascii, defaults to False
     """
     import vtk
     from vtk.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray
-    polydata = vtk.vtkPolyData()
 
+    file_path = _enforce_only_paths_supported(file_path, 'PLY')
+
+    polydata = vtk.vtkPolyData()
     points = vtk.vtkPoints()
     points.SetData(numpy_to_vtk(mesh.points))
     polydata.SetPoints(points)
 
     cells = vtk.vtkCellArray()
-    counts = np.tile([3], mesh.trilist.shape[0]).reshape((mesh.trilist.shape[0], 1))
-    tris = np.concatenate((counts, mesh.trilist), axis = 1)
+    counts = np.empty((mesh.trilist.shape[0], 1), dtype=np.int)
+    counts.fill(3)
+    tris = np.concatenate((counts, mesh.trilist), axis=1)
     cells.SetCells(mesh.trilist.shape[0], numpy_to_vtkIdTypeArray(tris))
     polydata.SetPolys(cells)
-
 
     if isinstance(mesh, TexturedTriMesh):
         pointdata = polydata.GetPointData()
         pointdata.SetTCoords(numpy_to_vtk(mesh.tcoords.points))
 
     ply_writer = vtk.vtkPLYWriter()
-    ply_writer.SetFileName(file_handle.name)
+    ply_writer.SetFileName(str(file_path))
     ply_writer.SetInputData(polydata)
     if not binary:
         ply_writer.SetFileTypeToASCII()
     else:
         ply_writer.SetFileTypeToBinary()
-    file_handle.close()
     ply_writer.Update()
     ply_writer.Write()

--- a/menpo3d/io/test/io_export_test.py
+++ b/menpo3d/io/test/io_export_test.py
@@ -1,9 +1,24 @@
+import contextlib
+import os
+import tempfile
 from mock import patch, PropertyMock, MagicMock
 import menpo3d.io as mio
 
 
 test_obj = mio.import_builtin_asset('james.obj')
 test_lg = mio.import_landmark_file(mio.data_path_to('bunny.ljson'))
+
+
+@contextlib.contextmanager
+def _temporary_path(extension):
+    # Create a temporary file and remove it
+    fake_path = tempfile.NamedTemporaryFile(delete=False, suffix=extension)
+    fake_path.close()
+    fake_path = fake_path.name
+    os.unlink(fake_path)
+    yield fake_path
+    if os.path.exists(fake_path):
+        os.unlink(fake_path)
 
 
 @patch('menpo3d.io.output.base.Path.exists')
@@ -15,14 +30,18 @@ def test_export_mesh_obj(mock_open, exists):
         type(f).name = PropertyMock(return_value=fake_path)
         mio.export_mesh(test_obj, f, extension='obj')
 
-@patch('menpo3d.io.output.base.Path.exists')
-@patch('{}.open'.format(__name__), create=True)
-def test_export_mesh_ply(mock_open, exists):
-    exists.return_value = False
-    fake_path = '/fake/fake.ply'
-    with open(fake_path) as f:
-        type(f).name = PropertyMock(return_value=fake_path)
-        mio.export_mesh(test_obj, f, extension='ply')
+
+def test_export_mesh_ply_ascii():
+    with _temporary_path('.ply') as f:
+        mio.export_mesh(test_obj, f)
+        assert os.path.exists(f)
+
+
+def test_export_mesh_ply_binary():
+    with _temporary_path('.ply') as f:
+        mio.export_mesh(test_obj, f, binary=True)
+        assert os.path.exists(f)
+
 
 @patch('PIL.Image.EXTENSION')
 @patch('menpo.image.base.PILImage')
@@ -36,6 +55,7 @@ def test_export_mesh_obj_textured(mock_open, exists, PILImage, PIL):
     mio.export_textured_mesh(test_obj, fake_path, extension='obj')
     assert PILImage.fromarray.called
 
+
 @patch('PIL.Image.EXTENSION')
 @patch('menpo.image.base.PILImage')
 @patch('menpo3d.io.output.base.Path.exists')
@@ -43,13 +63,11 @@ def test_export_mesh_obj_textured(mock_open, exists, PILImage, PIL):
 def test_export_mesh_ply_textured(mock_open, exists, PILImage, PIL):
     PIL.return_value.Image.EXTENSION = {'.jpg': None}
     exists.return_value = False
-    fake_path = '/fake/fake.ply'
-    MagicMock.name = PropertyMock(return_value=fake_path)
-    m = MagicMock()
-    #type(m).name = fake_path
-    mock_open.return_value = m
-    mio.export_textured_mesh(test_obj, fake_path, extension='ply')
-    assert PILImage.fromarray.called
+    mock_open.return_value = MagicMock()
+    with _temporary_path('.ply') as f:
+        mio.export_textured_mesh(test_obj, f)
+        assert PILImage.fromarray.called
+
 
 @patch('menpo.io.output.landmark.json.dump')
 @patch('menpo3d.io.output.base.Path.exists')


### PR DESCRIPTION
Since VTK exporters only support file paths and we were assuming that our exporters were passed a file handle our current export logic didn't work properly.

Therefore, I've add a PR to menpo [to allow this](https://github.com/menpo/menpo/pull/737) and this PR adds that functionality. This will fail until that is merged.